### PR TITLE
ci: add GitHub Actions workflow using nix flake devShell

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: "experimental-features = nix-command flakes"
+
+      - name: Run tests
+        run: nix develop --command make test


### PR DESCRIPTION
Runs `make test` inside `nix develop` on every push and PR. No separate plenary install step — it's provided by the flake.