### PR TITLE
test: add plenary test boilerplate

### DIFF
--- a/lua/frenchcards/init.lua
+++ b/lua/frenchcards/init.lua
@@ -332,6 +332,7 @@ function M.open_flashcard()
     vim.bo[buf].swapfile  = false
 
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, M.card_lines(M.current_card))
+    vim.b[buf].frenchcards_answer = M.current_card.a
 
     local line_count = vim.api.nvim_buf_line_count(buf)
     vim.api.nvim_win_set_cursor(0, { line_count, 0 })

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,0 +1,1 @@
+vim.opt.rtp:prepend(vim.fn.getcwd())


### PR DESCRIPTION
Adds `tests/minimal_init.lua` and stores the current card's answer as `vim.b.frenchcards_answer` so tests can read it from the buffer without touching module internals.