### PR TITLE
fix: seed math.random with os.time() for varied card selection

### DIFF
--- a/lua/frenchcards/init.lua
+++ b/lua/frenchcards/init.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+math.randomseed(os.time())
+
 M.cards = {
     { q = "I will speak to him", a = "Je lui parlerai" },
     { q = "They do not have", a = "Ils n'ont pas", meta = "masc" },


### PR DESCRIPTION
Lua's `math.random` uses a fixed default seed, so the same sequence of cards was picked every session. Seeding with `os.time()` at module load gives a different sequence each time.