### PR TITLE
test: add test suite boilerplate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	@./scripts/run_tests

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+TESTS_INIT=tests/minimal_init.lua
+TESTS_DIR=tests/
+
+nvim \
+    --headless \
+    --noplugin \
+    -u ${TESTS_INIT} \
+    -c "PlenaryBustedDirectory ${TESTS_DIR} { minimal_init = '${TESTS_INIT}' }"

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,0 +1,4 @@
+vim.opt.swapfile = false
+vim.opt.runtimepath:append('.')
+vim.cmd('runtime plugin/plenary.vim')
+vim.cmd('runtime plugin/frenchcards.lua')


### PR DESCRIPTION
Copies the test suite boilerplate from anakin4747/ai.nvim: `tests/minimal_init.lua`, `scripts/run_tests`, and a `Makefile` with a `make test` target.