### PR TITLE
ci: run tests on push and pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: tests
 
 on:
+  push:
   pull_request:
 
 jobs:


### PR DESCRIPTION
Adds `push` to the CI trigger so tests run on every push, not just on PRs.