### PR TITLE
fix: add plenary to runtimepath in minimal_init.lua

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - uses: rhysd/action-setup-vim@v1
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/plenary.nvim"]
+	path = vendor/plenary.nvim
+	url = https://github.com/nvim-lua/plenary.nvim

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,4 +1,5 @@
 vim.opt.swapfile = false
 vim.opt.runtimepath:append('.')
+vim.opt.runtimepath:append('vendor/plenary.nvim')
 vim.cmd('runtime plugin/plenary.vim')
 vim.cmd('runtime plugin/frenchcards.lua')


### PR DESCRIPTION
`scripts/run_tests` passes `--noplugin` which skips pack auto-loading. Plenary needs to be added to runtimepath explicitly so the test runner can find it.